### PR TITLE
doc: comply with AGPL license

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ Kibana 4.3+
 ```$ bin/kibana plugin -i vectormap -u https://github.com/stormpython/vectormap/archive/master.zip```
 
 ### Disclosure
-This repo is in its early stages. 
+This repo is in its early stages.
+
+This repo contains source code minified from the original source code [jvectormap](https://github.com/bjornd/jvectormap), which is licensed under [AGPL](https://github.com/bjornd/jvectormap/blob/master/LICENSE-AGPL).
 
 ### Issues
 Please file issues [here](https://github.com/stormpython/vectormap/issues).


### PR DESCRIPTION
Library jvectormap is used in a minified version: https://github.com/stormpython/vectormap/blob/master/public/lib/jvectormap/jquery-jvectormap.min.js.

To comply with AGPL, a reference to the source code and to the license has be provided

This PR provides both.